### PR TITLE
redundant import, + ignore_for_file to comply IDE

### DIFF
--- a/lib/models/myipvc/curricular_unit.dart
+++ b/lib/models/myipvc/curricular_unit.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: non_constant_identifier_names
+
 import 'package:json_annotation/json_annotation.dart';
 
 part 'curricular_unit.g.dart';

--- a/lib/models/myipvc/detailed_curricular_unit.dart
+++ b/lib/models/myipvc/detailed_curricular_unit.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: non_constant_identifier_names
+
 import 'package:json_annotation/json_annotation.dart';
 
 part 'detailed_curricular_unit.g.dart';

--- a/lib/models/myipvc/lesson.dart
+++ b/lib/models/myipvc/lesson.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: non_constant_identifier_names
+
 import 'package:json_annotation/json_annotation.dart';
 
 part 'lesson.g.dart';

--- a/lib/models/myipvc/user.dart
+++ b/lib/models/myipvc/user.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: non_constant_identifier_names
+
 import 'package:json_annotation/json_annotation.dart';
 
 part 'user.g.dart';

--- a/lib/providers/sharedPreferencesProvider.dart
+++ b/lib/providers/sharedPreferencesProvider.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: file_names
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 

--- a/lib/ui/themes/esa.dart
+++ b/lib/ui/themes/esa.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: non_constant_identifier_names
+
 import 'package:flex_color_scheme/flex_color_scheme.dart';
 import 'package:flutter/material.dart';
 

--- a/lib/ui/themes/esce.dart
+++ b/lib/ui/themes/esce.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: non_constant_identifier_names
+
 import 'package:flex_color_scheme/flex_color_scheme.dart';
 import 'package:flutter/material.dart';
 

--- a/lib/ui/themes/esdl.dart
+++ b/lib/ui/themes/esdl.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: non_constant_identifier_names
+
 import 'package:flex_color_scheme/flex_color_scheme.dart';
 import 'package:flutter/material.dart';
 

--- a/lib/ui/themes/ese.dart
+++ b/lib/ui/themes/ese.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: non_constant_identifier_names
+
 import 'package:flex_color_scheme/flex_color_scheme.dart';
 import 'package:flutter/material.dart';
 

--- a/lib/ui/themes/ess.dart
+++ b/lib/ui/themes/ess.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: non_constant_identifier_names
+
 import 'package:flex_color_scheme/flex_color_scheme.dart';
 import 'package:flutter/material.dart';
 

--- a/lib/ui/themes/estg.dart
+++ b/lib/ui/themes/estg.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: non_constant_identifier_names
+
 import 'package:flex_color_scheme/flex_color_scheme.dart';
 import 'package:flutter/material.dart';
 

--- a/lib/ui/themes/ipvc.dart
+++ b/lib/ui/themes/ipvc.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: non_constant_identifier_names
+
 import 'package:flex_color_scheme/flex_color_scheme.dart';
 import 'package:flutter/material.dart';
 

--- a/lib/ui/widgets/lesson_details.dart
+++ b/lib/ui/widgets/lesson_details.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:goipvc/services/get_status_from_color.dart';

--- a/lib/ui/widgets/menu_list_tile.dart
+++ b/lib/ui/widgets/menu_list_tile.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 class MenuListTile<T> extends StatelessWidget {

--- a/lib/ui/widgets/profile_card.dart
+++ b/lib/ui/widgets/profile_card.dart
@@ -25,7 +25,7 @@ class ProfileCard<T> extends ConsumerWidget {
           child: InkWell(
               onTap: () {
                 Navigator.push(context,
-                    MaterialPageRoute(builder: (context) => ProfileView()));
+                    MaterialPageRoute(builder: (context) => const ProfileView()));
               },
               child: Padding(
                   padding: const EdgeInsets.all(16),


### PR DESCRIPTION
`package:flutter/cupertino.dart` is unnecessary in the changed files because all of the used elements are also provided by the import of `package:flutter/material.dart`

`ignore_for_file` was added to few files to comply with my IDE, pls thank u <3