### PR TITLE
 improved class type display and interaction

### DIFF
--- a/lib/models/myipvc/curricular_unit.dart
+++ b/lib/models/myipvc/curricular_unit.dart
@@ -46,7 +46,7 @@ class MyIPVCCurricularUnit {
   String cdRamo;
 
   @JsonKey(name: 'nm_ramo')
-  String nmRamo;
+  String? nmRamo;
 
   @JsonKey(name: 'cd_discip')
   String cdDiscip;

--- a/lib/ui/views/curricular_unit.dart
+++ b/lib/ui/views/curricular_unit.dart
@@ -77,6 +77,7 @@ class CurricularUnitView extends StatelessWidget {
                           padding: const EdgeInsets.symmetric(horizontal: 3),
                           child: GestureDetector(
                             onTap: () {
+                              ScaffoldMessenger.of(context).clearSnackBars();
                               ScaffoldMessenger.of(context).showSnackBar(
                                 SnackBar(
                                   content: Text('${classType[tuple.item1]}'),

--- a/lib/ui/views/curricular_unit.dart
+++ b/lib/ui/views/curricular_unit.dart
@@ -5,6 +5,14 @@ import 'package:goipvc/services/myipvc_api.dart';
 import 'package:goipvc/ui/views/error.dart';
 import 'package:goipvc/ui/views/loading.dart';
 import 'package:goipvc/ui/widgets/curricular_unit_info_card.dart';
+import 'package:tuple/tuple.dart';
+
+final Map<String, String> classType = {
+  'p': 'Prática',
+  'pl': 'Prática-Laboratorial',
+  't': 'Teórica',
+  'tp': 'Teórica-Prática',
+};
 
 class CurricularUnitView extends StatelessWidget {
   final MyIPVCCurricularUnit curricularUnit;
@@ -20,99 +28,107 @@ class CurricularUnitView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (curricularUnit.tp == "-") {
-      curricularUnit.tp = "0.00";
-    }
-
-    if (curricularUnit.pl == "-") {
-      curricularUnit.pl = "0.00";
-    }
+    var dECTS = double.parse(curricularUnit.ects),
+        dP = curricularUnit.p != "" && curricularUnit.p != "-"
+            ? double.parse(curricularUnit.p)
+            : 0,
+        dPL = curricularUnit.pl != "" && curricularUnit.pl != "-"
+            ? double.parse(curricularUnit.pl)
+            : 0,
+        dT = curricularUnit.t != "" && curricularUnit.t != "-"
+            ? double.parse(curricularUnit.t)
+            : 0,
+        dTP = curricularUnit.tp != "" && curricularUnit.tp != "-"
+            ? double.parse(curricularUnit.tp)
+            : 0;
 
     return Scaffold(
         appBar: AppBar(
           title: const Text("Programa"),
         ),
         body: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 10),
-          child: ListView(
-            children: [
-              const Padding(padding: EdgeInsets.symmetric(vertical: 8)),
-              Text(
-                curricularUnit.nmUnidadeCurricular,
-                style: const TextStyle(fontSize: 24),
-                textAlign: TextAlign.center,
-              ),
-              Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 4),
-                  child: Text(
-                    "ECTS: ${curricularUnit.ects}",
-                    style: const TextStyle(fontSize: 14),
-                    textAlign: TextAlign.center,
-                  )),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Chip(
-                      avatar: const Icon(Icons.schedule),
-                      label: Text("TP: ${curricularUnit.tp} horas")),
-                  const Padding(padding: EdgeInsets.symmetric(horizontal: 8)),
-                  Chip(
-                      avatar: const Icon(Icons.schedule),
-                      label: Text("PL: ${curricularUnit.pl} horas")),
-                ],
-              ),
-              const Padding(padding: EdgeInsets.symmetric(vertical: 4)),
-              FutureBuilder(
-                future: _getDetailedCurricularUnit(),
-                builder: (context, snapshot) {
-                  if(snapshot.hasData) {
-                    return Column(
-                      children: [
-                        CurricularUnitInfoCard(
-                            title: "Responsável",
-                            body: Text(snapshot.data!.docentes)),
-                        CurricularUnitInfoCard(
-                            title: "Resumo", body: Text(snapshot.data!.resumo)),
-                        CurricularUnitInfoCard(
-                            title: "Objetivos da aprendizagem",
-                            body: Text(snapshot.data!.objetivos)),
-                        CurricularUnitInfoCard(
-                            title: "Conteúdos programáticos",
-                            body: Text(snapshot.data!.conteudos)),
-                        CurricularUnitInfoCard(
-                            title: "Metodologias de ensino",
-                            body: Text(snapshot.data!.metodologias)),
-                        CurricularUnitInfoCard(
-                            title: "Avaliação",
-                            body: Text(snapshot.data!.avaliacao)),
-                        CurricularUnitInfoCard(
-                            title: "Bibliografia principal",
-                            body: Text(snapshot.data!.bibliografiaPrincipal)),
-                        CurricularUnitInfoCard(
-                            title: "Bibliografia complementar",
-                            body: Text(snapshot.data!.bibliografiaComplementar))
-                      ],
-                    );
-                  } else if (snapshot.hasError) {
-                    return ErrorView(
-                      error: snapshot.error.toString(),
-                    );
-                  }
+            padding: const EdgeInsets.symmetric(horizontal: 10),
+            child: ListView(
+              children: [
+                const Padding(padding: EdgeInsets.symmetric(vertical: 8)),
+                Text(
+                  curricularUnit.nmUnidadeCurricular,
+                  style: const TextStyle(fontSize: 24),
+                  textAlign: TextAlign.center,
+                ),
+                Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 4),
+                    child: Text(
+                      "ECTS: ${dECTS % 1 == 0 ? dECTS.toInt() : dECTS}",
+                      style: const TextStyle(fontSize: 14),
+                      textAlign: TextAlign.center,
+                    )),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    ...[
+                      if (dP != 0) Tuple2('P', dP % 1 == 0 ? dP.toInt() : dP),
+                      if (dPL != 0)
+                        Tuple2('PL', dPL % 1 == 0 ? dPL.toInt() : dPL),
+                      if (dT != 0) Tuple2('T', dT % 1 == 0 ? dT.toInt() : dT),
+                      if (dTP != 0)
+                        Tuple2('TP', dTP % 1 == 0 ? dTP.toInt() : dTP),
+                    ].map((tuple) => Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 3),
+                          child: Chip(
+                            avatar: const Icon(Icons.schedule),
+                            label: Text('${tuple.item1}: ${tuple.item2} horas'),
+                          ),
+                        )),
+                  ],
+                ),
+                const Padding(padding: EdgeInsets.symmetric(vertical: 4)),
+                FutureBuilder(
+                    future: _getDetailedCurricularUnit(),
+                    builder: (context, snapshot) {
+                      if (snapshot.hasData) {
+                        return Column(
+                          children: [
+                            CurricularUnitInfoCard(
+                                title: "Responsável",
+                                body: Text(snapshot.data!.docentes)),
+                            CurricularUnitInfoCard(
+                                title: "Resumo",
+                                body: Text(snapshot.data!.resumo)),
+                            CurricularUnitInfoCard(
+                                title: "Objetivos da aprendizagem",
+                                body: Text(snapshot.data!.objetivos)),
+                            CurricularUnitInfoCard(
+                                title: "Conteúdos programáticos",
+                                body: Text(snapshot.data!.conteudos)),
+                            CurricularUnitInfoCard(
+                                title: "Metodologias de ensino",
+                                body: Text(snapshot.data!.metodologias)),
+                            CurricularUnitInfoCard(
+                                title: "Avaliação",
+                                body: Text(snapshot.data!.avaliacao)),
+                            CurricularUnitInfoCard(
+                                title: "Bibliografia principal",
+                                body:
+                                    Text(snapshot.data!.bibliografiaPrincipal)),
+                            CurricularUnitInfoCard(
+                                title: "Bibliografia complementar",
+                                body: Text(
+                                    snapshot.data!.bibliografiaComplementar))
+                          ],
+                        );
+                      } else if (snapshot.hasError) {
+                        return ErrorView(
+                          error: snapshot.error.toString(),
+                        );
+                      }
 
-                  return const LoadingView();
-                }
-              )
-            ],
-          )
+                      return const LoadingView();
+                    })
+              ],
+            )
 
-
-
-
-
-
-
-
-          /*FutureBuilder(
+            /*FutureBuilder(
               future: _getDetailedCurricularUnit(),
               builder: (context, snapshot) {
                 if (snapshot.hasData) {
@@ -123,6 +139,6 @@ class CurricularUnitView extends StatelessWidget {
 
                 return const LoadingView();
               }),*/
-        ));
+            ));
   }
 }

--- a/lib/ui/views/curricular_unit.dart
+++ b/lib/ui/views/curricular_unit.dart
@@ -8,10 +8,10 @@ import 'package:goipvc/ui/widgets/curricular_unit_info_card.dart';
 import 'package:tuple/tuple.dart';
 
 final Map<String, String> classType = {
-  'p': 'Prática',
-  'pl': 'Prática-Laboratorial',
-  't': 'Teórica',
-  'tp': 'Teórica-Prática',
+  'P': 'Prática',
+  'PL': 'Prática-Laboratorial',
+  'T': 'Teórica',
+  'TP': 'Teórica-Prática',
 };
 
 class CurricularUnitView extends StatelessWidget {
@@ -75,9 +75,20 @@ class CurricularUnitView extends StatelessWidget {
                         Tuple2('TP', dTP % 1 == 0 ? dTP.toInt() : dTP),
                     ].map((tuple) => Padding(
                           padding: const EdgeInsets.symmetric(horizontal: 3),
-                          child: Chip(
-                            avatar: const Icon(Icons.schedule),
-                            label: Text('${tuple.item1}: ${tuple.item2} horas'),
+                          child: GestureDetector(
+                            onTap: () {
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                SnackBar(
+                                  content: Text('${classType[tuple.item1]}'),
+                                  duration: const Duration(seconds: 3),
+                                ),
+                              );
+                            },
+                            child: Chip(
+                              avatar: const Icon(Icons.schedule),
+                              label:
+                                  Text('${tuple.item1}: ${tuple.item2} horas'),
+                            ),
                           ),
                         )),
                   ],

--- a/lib/ui/views/curricular_unit.dart
+++ b/lib/ui/views/curricular_unit.dart
@@ -11,7 +11,7 @@ final Map<String, String> classType = {
   'P': 'Prática',
   'PL': 'Prática-Laboratorial',
   'T': 'Teórica',
-  'TP': 'Teórica-Prática',
+  'TP': 'Teórico-Prática',
 };
 
 class CurricularUnitView extends StatelessWidget {


### PR DESCRIPTION
- Modified the presentation of class type times and ECTS as follows:
  1. `6.00 ECTS` now appears as `6 ECTS`
  2. `6.25 ECTS` remains unchanged
  3. `10.00 horas` is now displayed as `10 horas`
  4. `10.25 horas` remains unchanged

- Implemented a feature where clicking on class type chips triggers a Snackbar displaying the corresponding acronym meanings.

- Enhanced the display by showing only non-null class types. For instance:
  1. If a specific class is categorized as a `Theoretical (T based)` class with 0 `Practice (P)` hours, it now presents only the `Theoretical` hours chip. This eliminates the scenario of having 2 chips, where one displays 0 hours.
